### PR TITLE
Fix the manifests of the two new packages.

### DIFF
--- a/control_system_stack/absolute_rpy_publisher/src/main.py
+++ b/control_system_stack/absolute_rpy_publisher/src/main.py
@@ -18,7 +18,7 @@ Publishing the absolute Roll, Pitch and Yaw
   - Reference: http://en.wikipedia.org/wiki/File:Yaw_Axis_Corrected.svg
 '''
 
-import roslib;roslib.load_manifest('mission_planner')
+import roslib;roslib.load_manifest('absolute_rpy_publisher')
 import rospy
 import rospy
 import time

--- a/mission_planner_stack/pose_server_python/manifest.xml
+++ b/mission_planner_stack/pose_server_python/manifest.xml
@@ -10,8 +10,7 @@
   <url>http://ros.org/wiki/pose_server_python</url>
   <depend package="rospy"/>
   <depend package="resources"/>
+  <depend package="kraken_msgs"/>
   <depend package="std_msgs"/>
 
 </package>
-
-

--- a/mission_planner_stack/pose_server_python/src/main.py
+++ b/mission_planner_stack/pose_server_python/src/main.py
@@ -1,4 +1,4 @@
-import roslib;roslib.load_manifest('mission_planner')
+import roslib;roslib.load_manifest('pose_server_python')
 import rospy
 import rospy
 import time


### PR DESCRIPTION
- Absolute RPY Publisher
- Pose Server Python

These packages loaded the manifests of the seabotix package. Now, these have been fixed.
