### PR TITLE
Fix logging inside Absolute RPY Publisher and Thruster Converter

### DIFF
--- a/control_system_stack/absolute_rpy_publisher/src/main.py
+++ b/control_system_stack/absolute_rpy_publisher/src/main.py
@@ -22,6 +22,7 @@ Publishing the absolute Roll, Pitch and Yaw
 
 import roslib;roslib.load_manifest('absolute_rpy_publisher')
 import rospy
+import sys
 import time
 
 from resources import topicHeader
@@ -30,6 +31,14 @@ import kraken_msgs
 import kraken_msgs
 from kraken_msgs.msg._imuData import imuData
 from kraken_msgs.msg._absoluteRPY import absoluteRPY
+
+verbose_flag = False
+for i in sys.argv:
+
+    if i == '--verbose' or i == '--debug':
+
+        verbose_flag = True
+        break
 
 # print topicHeader.SENSOR_IMU
 # print topicHeader.ABSOLUTE_RPY
@@ -57,16 +66,23 @@ def imuCallback(imu):
 	abrpy.pitch = pitch
 	abrpy.yaw   = yaw
 
-	print roll, pitch, yaw
+        rospy.logdebug('Roll: %s, Pitch: %s, Yaw: %s', roll, pitch, yaw)
 
-	absolute_rpy_publisher.publish(abrpy)
+        absolute_rpy_publisher.publish(abrpy)
 
 	# Store this in a message and publish it
+
+if verbose_flag:
+
+    rospy.init_node('absolute_rpy_publisher', log_level=rospy.DEBUG)
+
+else:
+
+    rospy.init_node('absolute_rpy_publisher')
 
 absolute_rpy_publisher = rospy.Publisher(name=topicHeader.ABSOLUTE_RPY, data_class=absoluteRPY, queue_size=10)
 
 rospy.Subscriber(name=topicHeader.SENSOR_IMU, data_class=imuData, callback=imuCallback)
 
-rospy.init_node('absolute_roll_pitch_yaw_publisher')
 
 rospy.spin()

--- a/control_system_stack/absolute_rpy_publisher/src/main.py
+++ b/control_system_stack/absolute_rpy_publisher/src/main.py
@@ -6,7 +6,7 @@ Publishing the absolute Roll, Pitch and Yaw
 - Axes :-
 
   - x -> Along the vehicle, pointing from the backplate to the front plate.
-  - y -> Perpendicular to the vehicle; Points from the left surge thruster, 
+  - y -> Perpendicular to the vehicle; Points from the left surge thruster,
          towards the right surge thruster.
   - z -> Normal to the vehicle; From the top of the hull, towards the DVL;
 
@@ -26,19 +26,12 @@ import sys
 import time
 
 from resources import topicHeader
+from resources import tools
 
 import kraken_msgs
 import kraken_msgs
 from kraken_msgs.msg._imuData import imuData
 from kraken_msgs.msg._absoluteRPY import absoluteRPY
-
-verbose_flag = False
-for i in sys.argv:
-
-    if i == '--verbose' or i == '--debug':
-
-        verbose_flag = True
-        break
 
 # print topicHeader.SENSOR_IMU
 # print topicHeader.ABSOLUTE_RPY
@@ -72,17 +65,10 @@ def imuCallback(imu):
 
 	# Store this in a message and publish it
 
-if verbose_flag:
-
-    rospy.init_node('absolute_rpy_publisher', log_level=rospy.DEBUG)
-
-else:
-
-    rospy.init_node('absolute_rpy_publisher')
+rospy.init_node('absolute_rpy_publisher', log_level=(rospy.DEBUG if tools.getVerboseTag(sys.argv) else rospy.INFO))
 
 absolute_rpy_publisher = rospy.Publisher(name=topicHeader.ABSOLUTE_RPY, data_class=absoluteRPY, queue_size=10)
 
 rospy.Subscriber(name=topicHeader.SENSOR_IMU, data_class=imuData, callback=imuCallback)
-
 
 rospy.spin()

--- a/control_system_stack/thruster_converter/src/thruster.cpp
+++ b/control_system_stack/thruster_converter/src/thruster.cpp
@@ -17,6 +17,7 @@
 #include <kraken_msgs/thrusterData6Thruster.h>
 #include <SerialPort/SerialPort.h>
 #include <resources/topicHeader.h>
+#include <resources/tools.h>
 
 float converter = 1.0;
 uint8_t offset = 0x80;
@@ -71,10 +72,10 @@ void thruster6callback(const kraken_msgs::thrusterData6ThrusterConstPtr msg)
     for(int i = 0; i<6 ; i++ )
     {
         inData[i] = msg->data[i];
-        ROS_INFO("indata[%d] : %f",i,inData[i]);
+        ROS_DEBUG("indata[%d] : %f",i,inData[i]);
         store = uint8_t((converter*inData[i]>(0xE6-0x80)?(0xE6):converter*inData[i]+0x80));
         store = uint8_t((converter*inData[i]<(0x19-0x80)?(0x19):converter*inData[i]+0x80));
-        ROS_INFO("store : %d",store);
+        ROS_DEBUG("store : %d",store);
 
         if (store > max)
         {
@@ -96,6 +97,13 @@ int main(int argc,char** argv)
 
     ros::init(argc ,argv, "seabotixConverter");
 
+    if(tools::getVerboseTag(argc, argv) && ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
+    {
+        ros::console::notifyLoggerLevelsChanged();
+    }
+
+    ROS_DEBUG("The verbosity of this node is set to DEBUG");
+
     ros::NodeHandle n;
     ros::Subscriber _sub4 = n.subscribe<kraken_msgs::thrusterData4Thruster>(topics::CONTROL_PID_THRUSTER4,2,thruster4callback);
     ros::Subscriber _sub6 = n.subscribe<kraken_msgs::thrusterData6Thruster>(topics::CONTROL_PID_THRUSTER6,2,thruster6callback);
@@ -115,4 +123,3 @@ int main(int argc,char** argv)
 
     return 0;
 }
-

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 #rosbuild_gensrv()
 
 #common commands for building c++ executables and libraries
-rosbuild_add_library(${PROJECT_NAME} src/topicHeader.cpp)
+rosbuild_add_library(${PROJECT_NAME} src/topicHeader.cpp src/tools.cpp)
 #target_link_libraries(${PROJECT_NAME} another_library)
 #rosbuild_add_boost_directories()
 #rosbuild_link_boost(${PROJECT_NAME} thread)

--- a/resources/include/resources/tools.h
+++ b/resources/include/resources/tools.h
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <string.h>
+
+namespace tools
+{
+
+bool getVerboseTag(int argc, char** argv);
+
+}

--- a/resources/src/resources/tools.py
+++ b/resources/src/resources/tools.py
@@ -1,0 +1,7 @@
+def getVerboseTag(argv):
+    verboseTags = ['--verbose', '--debug']
+    for i in argv:
+        if i in verboseTags:
+            return True
+
+    return False

--- a/resources/src/tools.cpp
+++ b/resources/src/tools.cpp
@@ -1,0 +1,21 @@
+#include "resources/tools.h"
+
+namespace tools
+{
+
+bool getVerboseTag(int argc, char** argv)
+{
+    char tag1[] = "--verbose";
+    char tag2[] = "--debug";
+
+    if (argc >= 2)
+    {
+        if (strcmp(argv[1], tag1) == 0 || strcmp(argv[1], tag2) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+}


### PR DESCRIPTION
- These two packages are in Python and CPP respectively.
- They can serve as references for moving other packages over to the proper logging style of ROS.
- Getting whether the verbose tag has been passed with the command has been abstracted into a function inside `resource` package, under the `tools` namespace.

cc @prudhvid  @auviitkgp/developers @auviitkgp/embedded-team 
