### PR TITLE
"topic" to "topics

### DIFF
--- a/vision_stack/task_marker/src/marker_server.cpp
+++ b/vision_stack/task_marker/src/marker_server.cpp
@@ -5,7 +5,7 @@
 
 Marker::Marker(std::string name, std::string _threshold_filepath) : _it(_n), _s(_n, name, boost::bind(&Marker::executeCB, this, _1), false), _actionName(name)
 {
-    _sub = _it.subscribe(topic::CAMERA_BOTTOM_RAW_IMAGE, 1, &Marker::imageCallBack, this);
+    _sub = _it.subscribe(topics::CAMERA_BOTTOM_RAW_IMAGE, 1, &Marker::imageCallBack, this);
     // _pub = _it.advertise("/kraken/bottomcam/marker_image", 1);
     _pub = _it.advertise(topics::CAMERA_BOTTOM_MARKER_IMAGE, 1);
     marker_detect_status=false;


### PR DESCRIPTION
In resources/topicHeader.h, the namespace was "topics. But in marker_server.cpp, "topic" namespace was being used and it was the reason behind build errors. That typo has been removed.
