### PR TITLE
Removed  typo from resources' CMakeLists.txt

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -64,5 +64,5 @@ catkin_package(
     DEPENDS roscpp rospy std_msgs
     CATKIN_DEPENDS # TODO
     INCLUDE_DIRS include # TODO include
-    LIBRARIES $(PROJECT_NAME)  # TODO
+    LIBRARIES # TODO
 )


### PR DESCRIPTION
Removed the $(PROJECT_NAME) typo in line 67 of resources/CMakeLists.txt